### PR TITLE
Fix Code Formatting CI Pipeline to Run Format Checks without Automated Commits (#80)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,9 +8,6 @@ on:
     branches:
       - main
 
-permissions:
-  contents: write
-
 jobs:
   format-check:
     runs-on: ubuntu-latest
@@ -29,36 +26,16 @@ jobs:
         python -m pip install --upgrade pip
         pip install black isort
 
-    - name: Run isort
+    - name: Run isort and check for unformatted files
       run: |
-        isort .
+        isort --check-only .
 
-    - name: Run black
+    - name: Run black and check for unformatted files
       run: |
-        black --line-length=120 .
+        black --check --line-length=120 .
 
-    - name: Configure Git
+    - name: Fail if formatting is incorrect
       run: |
-        git config user.name "GitHub Actions"
-        git config user.email "actions@github.com"
-
-    - name: Check if any files were modified
-      run: |
-        git diff --exit-code || git commit -am "Auto-format code with isort and black"
-
-    - name: Pull latest changes
-      run: |
-        if [ "${{ github.event_name }}" = "pull_request" ]; then
-          git pull --no-rebase origin ${{ github.event.pull_request.head.ref }}
-        else
-          git pull --no-rebase origin main
-        fi
-
-    - name: Push changes
-      if: success()
-      run: |
-        if [ "${{ github.event_name }}" = "pull_request" ]; then
-          git push origin HEAD:${{ github.event.pull_request.head.ref }};
-        else
-          git push origin HEAD:main;
-        fi
+        echo "Code is not formatted correctly. Please run 'isort .' and 'black --line-length=120 .' locally to fix."
+        exit 1
+      if: failure()


### PR DESCRIPTION
# What does this PR do?

This PR fixes the broken CI/CD automation for code formatting as outlined in issue #80. The changes made ensure that the formatting tools `isort` and `black` are checked for compliance without attempting automated commits or pushes, thereby simplifying the process and preventing permission issues.

### Changes Made:
- **Removed Automated Commits**: Eliminated steps that attempted to commit and push changes automatically.
- **Updated to Check-Only Mode**: The pipeline now runs `isort` and `black` in check-only mode, failing the job if formatting issues are found.
- **Enhanced Contributor Experience**: Contributors are prompted to fix formatting locally before submitting a pull request.

### Motivation and Context:
The previous setup was causing frequent failures and required maintainer approval for public pull requests, leading to a cumbersome experience for contributors. By allowing contributors to run formatting tools locally, we can ensure a cleaner and more efficient development process.

### Dependencies:
No new dependencies are introduced with this change.

Fixes #80 (issue).

## Before submitting
- [x] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Was this discussed/approved via a GitHub issue? Please add a link to it if that's the case.
- [ ] Did you make sure to update the documentation with your changes?
- [ ] Did you write any new necessary tests?

## Who can review?
Anyone in the community is free to review the PR once the tests have passed. Feel free to tag members/contributors who may be interested in your PR.
