### PR TITLE
Make filepath separator OS-independent

### DIFF
--- a/sage/data_manager.py
+++ b/sage/data_manager.py
@@ -159,7 +159,7 @@ class GitHubRepoManager(DataManager):
         _, extension = os.path.splitext(file_path)
         extension = extension.lower()
         file_name = os.path.basename(file_path)
-        dirs = os.path.dirname(file_path).split("/")
+        dirs = os.path.dirname(file_path).split(os.sep)
 
         if self.inclusions:
             return (


### PR DESCRIPTION
# What does this PR do?
This PR fixes an issue with inclusion and exclusion lists not being taken into account correctly for directories on Windows machines due to a hard-coded separator character.
Replaced the hard-coded `"/"` with a `os.sep` to make the filepath separator OS-independent.
